### PR TITLE
look for libdiscid.0.dylib

### DIFF
--- a/lib/discid/lib.rb
+++ b/lib/discid/lib.rb
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 require "ffi"
+require "rbconfig"
 
 module DiscId
 
@@ -24,7 +25,12 @@ module DiscId
   # @private
   module Lib
     extend FFI::Library
-    ffi_lib %w[discid, libdiscid.so.0, libdiscid.0.dylib]
+    case RbConfig::CONFIG['host_os']
+      when /darwin/i
+        ffi_lib %w[discid, libdiscid.0.dylib]
+      else
+        ffi_lib %w[discid, libdiscid.so.0]
+    end
 
     attach_function :new, :discid_new, [], :pointer
 


### PR DESCRIPTION
This is the file name provided in the official Mac distribution of libdiscid
and a library in the current folder will be found.
A system-wide install is also found using this name, but not without it.

I somehow wasn't allowed to attach the commit to #6.
Not sure what the exact requirement is. I could do that to repositories without commit access before. Possibly only when I created the issue.
