### PR TITLE
search for local libdiscid

### DIFF
--- a/lib/discid/lib.rb
+++ b/lib/discid/lib.rb
@@ -24,7 +24,7 @@ module DiscId
   # @private
   module Lib
     extend FFI::Library
-    ffi_lib %w[discid libdiscid.so.0]
+    ffi_lib %w[discid libdiscid.so.0 ./libdiscid.so.0 libdiscid.0.dylib]
 
     attach_function :new, :discid_new, [], :pointer
 


### PR DESCRIPTION
This will additionally search for libdiscid in the current folder.
Darwin needs this since the official standalone name is not `libdiscid.dylib`
and Linux because it won't search in the current folder if not
explicitely asked.
Windows should be fine as is.

Not sure if you want that functionality, but for things like isrcsubmit I depend on finding local libdiscid to distribute packages with included libdiscid.
More important on Windows and Mac than with Linux. Since Linux includes libdiscid in most repositories anyways.

This is an optional addition to #6
